### PR TITLE
Added a command to abandon a single skill

### DIFF
--- a/Respec/RespecCommands.cs
+++ b/Respec/RespecCommands.cs
@@ -64,6 +64,30 @@ namespace Eco.Mods
             toSet.Skillset.AddExperience(foundSkill.Type, skillPoints, Localizer.DoStr("dev command"));
             user.Player.Msg(Localizer.Format("Added {0} to skill {1}.", skillPoints, foundSkill.Name));
         }
+
+        [ChatSubCommand("Skills", "Abandon a given skill for yourself or a given player.", ChatAuthorizationLevel.Admin)]
+        public static void AbandonSkill(User user, string skillName, User targetUser = null)
+        {
+            User toSet = targetUser == null ? user : targetUser;
+
+            Skill foundSkill = null;
+            foreach (Skill s in toSet.Skillset.Skills)
+            {
+                if (!s.IsRoot && s.Name.ToLower().Contains(skillName.ToLower()))
+                {
+                    foundSkill = s;
+                    break;
+                }
+            }
+            if (foundSkill == null || foundSkill.Name.Equals("SelfImprovementSkill"))
+            {
+                user.Player.Error(Localizer.Format("Skill {0} not found.", skillName));
+                return;
+            }
+			foundSkill.AbandonSpecialty(targetUser.Player);
+            targetUser.Player.Client.RPCAsync<bool>("PopupConfirmBox", targetUser.Player.Client, Localizer.Format("Your {0} skill has been abandoned. Please disconnect and reconnect immediately.", foundSkill.Name));
+            user.Player.Msg(Localizer.Format("Abandoned skill {0}.", foundSkill.Name));
+        }
     }
 
 }

--- a/Respec/RespecCommands.cs
+++ b/Respec/RespecCommands.cs
@@ -84,8 +84,8 @@ namespace Eco.Mods
                 user.Player.Error(Localizer.Format("Skill {0} not found.", skillName));
                 return;
             }
-			foundSkill.AbandonSpecialty(targetUser.Player);
-            targetUser.Player.Client.RPCAsync<bool>("PopupConfirmBox", targetUser.Player.Client, Localizer.Format("Your {0} skill has been abandoned. Please disconnect and reconnect immediately.", foundSkill.Name));
+			foundSkill.AbandonSpecialty(toSet.Player);
+            toSet.Player.Client.RPCAsync<bool>("PopupConfirmBox", toSet.Player.Client, Localizer.Format("Your {0} skill has been abandonned. Please disconnect and reconnect immediately to resync your skills", foundSkill.Name));
             user.Player.Msg(Localizer.Format("Abandoned skill {0}.", foundSkill.Name));
         }
     }


### PR DESCRIPTION
I had a case on a server set up specifically for a group of friends that were pretty new to the game. 
And a lot of them ended up either speccing into jobs that were already taken or kinda getting driven into jobs they didn't like as a result.

However, since the respec mod only allowed you to fully respec your entire character this resulted in a lot of them not wanting to respec as it would mean they'd lose everything else they did wanna keep as well.

As a result, I added a command to abandon a single skill and I thought I'd submit it to you as well in case you might find it useful.

I initially planned on just requesting you add this to the mod, but I thought since I needed it why not try to add it myself and just make a pull request to save you the hassle.

