### PR TITLE
Increased the search radius of conveyor belts for nearby neighbours.

### DIFF
--- a/ConveyorBeltUpdate/ConveyorBeltObject.cs
+++ b/ConveyorBeltUpdate/ConveyorBeltObject.cs
@@ -102,7 +102,7 @@ namespace Eco.Mods.TechTree
       Vector3i blockTop = wantedPosition + new Vector3i(0, 1, 0);
       Vector3i blockBottom = wantedPosition + new Vector3i(0, -1, 0);
 
-      IEnumerable<WorldObject> list = NetObjectManager.GetObjectsWithin(this.Position3i, 5f).OfType<WorldObject>();
+      IEnumerable<WorldObject> list = NetObjectManager.GetObjectsWithin(this.Position3i, 7f).OfType<WorldObject>();
       if (list == null) return;
 
       foreach (WorldObject item in list)


### PR DESCRIPTION
Entities are found based on the location of their center. But a LargeLumberStockpile is so large, that a conveyor placed next to it could never be within 5 blocks of it its center.